### PR TITLE
Customisable location for yo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PKGNAME=yo-yo
-PKGVERSION=0.0.2
+PKGVERSION=0.0.3
 PKGID=com.github.groob.yo-yo
 
 all: build pkg
@@ -8,5 +8,3 @@ build:
 pkg: build
 	mkdir -p out
 	pkgbuild --root pkg/pkgroot --identifier ${PKGID} --version ${PKGVERSION} --scripts pkg/scripts out/${PKGNAME}-${PKGVERSION}.pkg
-
-	

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Like [outset](https://github.com/chilcote/outset) for [yo](https://github.com/sheagcraig/yo)
 
-yo-yo traverses a directory for json or plist formatted code parameters for Yo, and creates notifications using yo. 
+yo-yo traverses a directory for json or plist formatted code parameters for Yo, and creates notifications using yo.
 Installing a LaunchAgent to watch a directory and trigger yo-yo allows applications running as root to deliver notifications to the session.
-yo-yo deletes the notification file after successfuly executing `yo`, promising at most once delivery. This won't work in a multi user context.
+yo-yo deletes the notification file after successfully executing `yo`, promising at most once delivery. This won't work in a multi user context.
 
 Notification file example:
 The keys in the json or plist file mirror yo's cli flags.
@@ -19,3 +19,8 @@ The keys in the json or plist file mirror yo's cli flags.
 </dict>
 </plist>
 ```
+
+yo-yo accepts the following options:
+
+* `-n`: The directory containing the files for notifications.
+* `-p`: The path to the Yo executable. Defaults to `/usr/local/bin/yo`.

--- a/main.go
+++ b/main.go
@@ -17,6 +17,8 @@ import (
 
 var notificationDir = flag.String("n", "", "path to Yo notification files")
 
+var yoPath = flag.String("p", "/usr/local/bin/yo", "path to Yo executable")
+
 type yoOpts struct {
 	Title          string `json:"title" plist:"title"`
 	Subtitle       string `json:"subtitle" plist:"subtitle"`
@@ -98,7 +100,7 @@ func (yo yoOpts) toStringArray() []string {
 
 func (yo yoOpts) run() error {
 
-	cmd := exec.Command("/usr/local/bin/yo", yo.toStringArray()...)
+	cmd := exec.Command(*yoPath, yo.toStringArray()...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr


### PR DESCRIPTION
This allows you to change the path for `yo` (in case you want it in `/opt/bin` for example). It also documents these options.